### PR TITLE
vectorflow.math: Enable flushing denormals to zero

### DIFF
--- a/src/vectorflow/losses.d
+++ b/src/vectorflow/losses.d
@@ -66,7 +66,7 @@ auto get_grad(T, alias WITH_VAL, V...)(string loss, V args)
             " attribute.");
 
     static if(__traits(hasMember, T, "weight"))
-        ct_msg!("Using `weight` attribute to perform weighted MLE inference");
+        mixin ct_msg!("Using `weight` attribute to perform weighted MLE inference");
     switch(loss)
     {
         case "logistic":

--- a/src/vectorflow/math.d
+++ b/src/vectorflow/math.d
@@ -105,6 +105,7 @@ static this()
 {
     // Enable flushing denormals to zero
     enum FTZ_BIT = 15;
+    enum DAZ_BIT = 6;
 
     // Manually align to 16 bytes - https://issues.dlang.org/show_bug.cgi?id=16098
     uint[128 + 4] buf;
@@ -115,5 +116,6 @@ static this()
         asm { mov EAX, state; fxsave 0[EAX]; }
     uint mxcsr = state[6];
     mxcsr |= 1 << FTZ_BIT;
+    mxcsr |= 1 << DAZ_BIT;
     asm { ldmxcsr mxcsr; }
 }

--- a/src/vectorflow/math.d
+++ b/src/vectorflow/math.d
@@ -100,3 +100,15 @@ else
 {
     mixin Functions!();
 }
+
+static this()
+{
+    // Enable flushing denormals to zero
+    enum FTZ_BIT = 15;
+
+    align(16) uint[128] state;
+    asm { fxsave state; }
+    uint mxcsr = state[6];
+    mxcsr |= 1 << FTZ_BIT;
+    asm { ldmxcsr mxcsr; }
+}

--- a/src/vectorflow/math.d
+++ b/src/vectorflow/math.d
@@ -101,6 +101,13 @@ else
     mixin Functions!();
 }
 
+version (X86)
+    version = X86_Any;
+else
+version (X86_64)
+    version = X86_Any;
+
+version (X86_Any)
 static this()
 {
     // Enable flushing denormals to zero

--- a/src/vectorflow/neuralnet.d
+++ b/src/vectorflow/neuralnet.d
@@ -750,8 +750,5 @@ private void optimize_graph(NeuralNet net)
 
 version(assert)
 {
-    static this()
-    {
-        ct_msg!("Non-release build.");
-    }
+    mixin ct_msg!("Non-release build.");
 }

--- a/src/vectorflow/utils.d
+++ b/src/vectorflow/utils.d
@@ -255,7 +255,7 @@ final class Hasher {
     }
 }
 
-package static void ct_msg(string msg)()
+package mixin template ct_msg(string msg)
 {
     pragma(msg, "[VECTORFLOW-COMPILE] " ~ msg);
 }


### PR DESCRIPTION
I noticed that when I built the mnist example with LDC and optimizations enabled, the displayed loss was NaN and the network wasn't being trained (classification error remained at 0.9). I tracked this down to some vector operations on denormal floats resulting in NaNs, which then propagated all over the place.

The fix is simple - enable the FPU mode to flush denormals to zero.

This gets the mnist example working properly on my machine when built with LDC and optimizations.