### PR TITLE
Fix nans in LDC fastmath

### DIFF
--- a/src/vectorflow/layers.d
+++ b/src/vectorflow/layers.d
@@ -88,7 +88,12 @@ class Linear : NeuralLayer {
                 final switch(l.type)
                 {
                     case LayerT.DENSE:
-                        dp += dotProd(row[offset..offset+l.dim_out], l.out_d);
+                        auto dp_ret = dotProd(row[offset..offset+l.dim_out], l.out_d);
+                        import std.math : isNaN;
+                        if (isNaN(dp_ret)) {
+                            throw new Exception("Got NaN dotProd() on layer " ~ l.toString);
+                        }
+                        dp += dp_ret;
                         break;
                     
                     case LayerT.SPARSE:

--- a/src/vectorflow/optimizers.d
+++ b/src/vectorflow/optimizers.d
@@ -522,10 +522,14 @@ class ADAM : SGDOptimizer {
                 float[] row_W, float[] row_S, float[] row_M,
                 float beta1_, float beta2_, float eps_, float lr_) pure
         {
-            float k1 = 1.0/(1.0 - beta1_);
-            float k2 = 1.0/(1.0 - beta2_);
-            for(int i = 0; i < row_W.length; ++i)
-                row_W[i] -= lr_ * k1 * row_M[i] / (sqrt(k2 * row_S[i]) + eps_);
+            double k1 = 1.0L / (1.0L - beta1_);
+            double k2 = 1.0L / (1.0L - beta2_);
+            for(int i = 0; i < row_W.length; ++i) {
+                double v1 = lr_ * k1 * row_M[i] ;
+                double v2 = sqrt(k2 * row_S[i]) + eps_;
+                double q = v1 / v2;
+                row_W[i] -= q;
+            }
         }
     }
 

--- a/src/vectorflow/regularizers.d
+++ b/src/vectorflow/regularizers.d
@@ -350,6 +350,9 @@ class RotationPrior : AdditiveLinearPrior
             auto ri = W[i];
             auto rj = W[j];
             float g = dotProd(ri, rj);
+            import std.math : isNaN;
+            if (isNaN(g))
+                { throw new Exception("Got NaN dotProd"); }
             if(i != j)
             {
                 foreach(u; 0..W[i].length)


### PR DESCRIPTION
Tracked down place where the NANs where created. Use double precision for operation fixes the problem with NANs here.

Also added two cheap checks for NANs, so the problem is at least detected at runtime.