### PR TITLE
Fix crosscompile to raspberry pi3 (arm ca7)

### DIFF
--- a/examples/rcv1.d
+++ b/examples/rcv1.d
@@ -39,7 +39,7 @@ auto load_data()
     {
         auto root_url = "http://ae.nflximg.net/vectorflow/";
         auto url_data = root_url ~ "lyrl2004_vectors_";
-        auto url_topics = root_url ~ "rcv1v2.topics.qrels.gz"; 
+        auto url_topics = root_url ~ "rcv1v2.topics.qrels.gz";
         mkdir(data_dir);
         import std.net.curl;
         import std.process;
@@ -87,7 +87,7 @@ bool[] load_labels(string cat_name)
         {
             toks.popFront();
             auto ind = to_long(toks.front);
-            labels[ind] = true;
+            labels[ind.to!size_t] = true;
         }
     }
     return labels;
@@ -122,9 +122,9 @@ class RCV1Reader : DataFileReader!(Obs) {
         auto lab_end = countUntil(buff, "  ");
         if(lab_end == -1)
             return false;
-        auto label = labels[to_long(buff[0..lab_end])];
+        auto label = labels[buff[0..lab_end].to!size_t];
         _obs.label = label;
-        ulong cnt = 0;
+        size_t cnt = 0;
 
         foreach(t; splitter(buff[lab_end+2..$], ' '))
         {
@@ -135,7 +135,7 @@ class RCV1Reader : DataFileReader!(Obs) {
             auto feat_val = to_float(t[feat_id_end+1..$]);
             features_buff[cnt++] = SparseF(feat_id, feat_val);
         }
-        
+
         _obs.features = features_buff[0..cnt];
         return true;
     }

--- a/examples/rcv1.d
+++ b/examples/rcv1.d
@@ -122,7 +122,7 @@ class RCV1Reader : DataFileReader!(Obs) {
         auto lab_end = countUntil(buff, "  ");
         if(lab_end == -1)
             return false;
-        auto label = labels[buff[0..lab_end].to!size_t];
+        auto label = labels[to_long(buff[0..lab_end]).to!size_t];
         _obs.label = label;
         size_t cnt = 0;
 

--- a/src/vectorflow/dataset.d
+++ b/src/vectorflow/dataset.d
@@ -1,6 +1,6 @@
 /**
  This module provides utility classes to iterate over data.
- 
+
  It is not mandatory to use them when using vectorflow, but you might find them
  useful and slightly more intuitive to use than the built-in range mechanism if
  you're a beginner with D.
@@ -12,7 +12,7 @@
  std.range.evenChunks, which might or might not work depending on your
  specific reader. To explicitly shard the data, just specify an `evenChunks`
  function in your reader implementation (see MultiFilesReader for an example).
- 
+
  Copyright: 2017 Netflix, Inc.
  License: $(LINK2 http://www.apache.org/licenses/LICENSE-2.0, Apache License Version 2.0)
  */
@@ -73,8 +73,7 @@ class DataFileReader(T) : DataReader!T
 class MultiFilesReader(T)
 {
     DataFileReader!(T)[] readers;
-
-    protected ulong _currInd;
+    protected size_t _currInd;
     public @property ulong currentFileIndex(){return _currInd;}
 
     private bool _cached;
@@ -110,7 +109,7 @@ class MultiFilesReader(T)
                     result = dg(obs);
                     if(result)
                         break;
-                }                
+                }
             }
         }
         rewind();


### PR DESCRIPTION
size_t has only 32 bit on the ARM platform. So we need some explicit
casts at the right place. Changed _currInd to be size_t, which matches
best here as it needs the least number of conversions later.