### PR TITLE
Fix deserialization on Windows

### DIFF
--- a/src/vectorflow/neuralnet.d
+++ b/src/vectorflow/neuralnet.d
@@ -432,7 +432,7 @@ class NeuralNet {
 
         if(!_ever_initialized)
         {
-            writeln("Net not initialized. Initializing all weights to 0.");
+            version(VectorflowPrint) writeln("Net not initialized. Initializing all weights to 0.");
             initialize(0.0);
         }
         {
@@ -458,7 +458,7 @@ class NeuralNet {
 
         auto cores_str = (
                 num_cores == 1 ? "1 core." : "%d cores.".format(num_cores));
-        writeln("Training net with ", num_params, " parameters on ", cores_str);
+        version(VectorflowPrint) writeln("Training net with ", num_params, " parameters on ", cores_str);
         foreach(l; layers)
             l.pre_learning();
         opt.learn(this, data, grad_f, verbose, num_cores);
@@ -597,12 +597,12 @@ class NeuralNet {
             f.close();
             try
             {
-                writeln("Serialization failed.");
+                version(VectorflowPrint) writeln("Serialization failed.");
                 remove(path);
             }
             catch(FileException e)
             {
-                writeln("Couldn't cleanup `", path,
+                version(VectorflowPrint) writeln("Couldn't cleanup `", path,
                         "` after serialization failure: ", e);
             }
         }

--- a/src/vectorflow/serde.d
+++ b/src/vectorflow/serde.d
@@ -117,7 +117,7 @@ class Serializer {
             auto l = Object.factory(layer_type).to!NeuralLayer;
             l.deser(this);
             layers ~= l;
-            writeln("Deserialized ", l.to!string);
+            version(VectorflowPrint) writeln("Deserialized ", l.to!string);
         }
 
         return layers;

--- a/test/common.d
+++ b/test/common.d
@@ -107,12 +107,12 @@ version(unittest)
                 }
             }
         }
-        writeln("----------");
+       version(VectorflowPrint)  writeln("----------");
         if(failed > 0)
         {
-            writefln("At least %d test(s) failed.", failed);
+            version(VectorflowPrint) writefln("At least %d test(s) failed.", failed);
             foreach(m; retro(messages))
-                writeln(m);
+                version(VectorflowPrint) writeln(m);
         }
         return failed == 0;
     }


### PR DESCRIPTION
On Windows, the `EOF` flag is not set as long as you don't read past the end of the file. That causes current deserialization algorithm to crash on Windows with obscure errors. I added special `version(Windows)` code into deserialization logic to handle Windows file reading. I left the original code untouched to make it distinguishable.

This PR makes `vectorflow` pass all the tests on windows, btw :^)