### PR TITLE
Delete override on templated methods

### DIFF
--- a/src/vectorflow/layers.d
+++ b/src/vectorflow/layers.d
@@ -473,7 +473,7 @@ class ReLU : NeuralLayer {
         }
     }
 
-    override void accumulate_grad(V)(V[] grad)
+    void accumulate_grad(V)(V[] grad)
         if ((is(V == float) || is(V == SparseF)))
     {
         ulong offset = 0;

--- a/src/vectorflow/neurallayer.d
+++ b/src/vectorflow/neurallayer.d
@@ -240,10 +240,10 @@ abstract class InputLayer : NeuralLayer
 
     abstract override void predict();
     
-    override void accumulate_grad(V)(V[] grad) pure
+    void accumulate_grad(V)(V[] grad) pure
         if ((is(V == float) || is(V == SparseF))) {}
 
-    override void backward_prop(V)(V[] grad) pure
+    void backward_prop(V)(V[] grad) pure
         if ((is(V == float) || is(V == SparseF))) {}
 
     override @property ulong num_params(){return 0;}


### PR DESCRIPTION
Template methods cannot be virtual because they can essentially populate the vtable infinitely. Override is accepted on templates, but it is ignored. A PR to dmd has been raised to make it an error [1] so that the user does not have false assumptions; that PR is currently blocked and will be unblocked by this PR.

[1] https://github.com/dlang/dmd/pull/15350